### PR TITLE
Remove OWASP dependency check from MR action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,10 +48,12 @@ jobs:
       - name: Build without tests
         run: ./gradlew --no-daemon build -x test -x contractTest
 
-  owasp-check:
-    uses: ./.github/workflows/owasp-dependencies-check.yml
-    with:
-      currentBranchName: ${{ github.ref }}
-    # https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows
-    secrets:
-      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+# skips running OWASP dependency check on merge requests
+# because dependabot MR are blocking each other on dependencyCheckUpgrade
+#  owasp-check:
+#    uses: ./.github/workflows/owasp-dependencies-check.yml
+#    with:
+#      currentBranchName: ${{ github.ref }}
+#    # https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows
+#    secrets:
+#      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Temporarily disabled the OWASP dependency check in the GitHub workflow to prevent blocking of dependabot merge requests.

- **Documentation**
	- Updated comments in the GitHub workflow file to reflect the reason for skipping the OWASP check on merge requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->