### PR TITLE
Enforce newest Spring context and run OWASP check on self-hosted

### DIFF
--- a/.github/workflows/owasp-dependencies-check.yml
+++ b/.github/workflows/owasp-dependencies-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   owasp-dependency-check:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       NVD_API_KEY: "${{ secrets.NVD_API_KEY }}"
     steps:

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -20,6 +20,14 @@ val vGroovy: String by rootProject.extra
 val vSpock: String by rootProject.extra
 val vSpringContractStubRunner: String by rootProject.extra
 
+dependencyManagement {
+    dependencies {
+        // newer versions to fix CVE-2025-22233
+        // https://spring.io/security/cve-2025-22233
+        dependency("org.springframework:spring-context:6.2.7")
+    }
+}
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -34,6 +34,11 @@ dependencyManagement {
     imports {
         mavenBom("com.fasterxml.jackson:jackson-bom:2.19.0")
     }
+    dependencies {
+        // newer versions to fix CVE-2025-22233
+        // https://spring.io/security/cve-2025-22233
+        dependency("org.springframework:spring-context:6.2.7")
+    }
 }
 
 dependencies {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the OWASP dependency check workflow to use a self-hosted runner.
  - Applied an explicit override for the Spring Context library to version 6.2.7 in both client and server components to address a security vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->