### PR TITLE
Switch back to GH runners

### DIFF
--- a/.github/workflows/owasp-dependencies-check.yml
+++ b/.github/workflows/owasp-dependencies-check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   owasp-dependency-check:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       NVD_API_KEY: "${{ secrets.NVD_API_KEY }}"
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the OWASP dependency check workflow to use the default GitHub-hosted runner environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->