### PR TITLE
Static imports should be before any other imports in Groovy

### DIFF
--- a/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/TestcontainersSpringBaseTest.groovy
+++ b/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/TestcontainersSpringBaseTest.groovy
@@ -1,5 +1,7 @@
 package pl.kubiczak.test.spring.integration.demo.server
 
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.util.TestPropertyValues
 import org.springframework.boot.test.web.server.LocalServerPort
@@ -10,8 +12,6 @@ import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.spock.Testcontainers
 import spock.lang.Specification
-
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 
 @Testcontainers
 @ContextConfiguration(initializers = [

--- a/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/cats/CatFactClientWithWireMockSpec.groovy
+++ b/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/cats/CatFactClientWithWireMockSpec.groovy
@@ -1,5 +1,7 @@
 package pl.kubiczak.test.spring.integration.demo.server.cats
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import org.springframework.beans.factory.annotation.Autowired
@@ -9,11 +11,6 @@ import org.springframework.test.context.TestPropertySource
 import pl.kubiczak.test.spring.integration.demo.server.cats.ports.CatFactClient
 import pl.kubiczak.test.spring.integration.demo.server.config.CatFactConfig
 import spock.lang.Specification
-
-import static com.github.tomakehurst.wiremock.client.WireMock.configureFor
-import static com.github.tomakehurst.wiremock.client.WireMock.get
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor
 
 @ContextConfiguration(classes = [CatFactConfig.class])
 @TestPropertySource(properties = ["apiDomain=http://localhost:8080"])

--- a/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/cats/CatsControllerMockMvcSpec.groovy
+++ b/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/cats/CatsControllerMockMvcSpec.groovy
@@ -1,12 +1,12 @@
 package pl.kubiczak.test.spring.integration.demo.server.cats
 
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.test.web.servlet.MockMvc
-import pl.kubiczak.test.spring.integration.demo.server.MockMvcSpringBaseTest
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.MockMvc
+import pl.kubiczak.test.spring.integration.demo.server.MockMvcSpringBaseTest
 
 class CatsControllerMockMvcSpec extends MockMvcSpringBaseTest {
 

--- a/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/employees/EmployeesControllerMockMvcSpec.groovy
+++ b/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/employees/EmployeesControllerMockMvcSpec.groovy
@@ -1,14 +1,12 @@
 package pl.kubiczak.test.spring.integration.demo.server.employees
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.json.JsonCompareMode
 import org.springframework.test.web.servlet.MockMvc
 import pl.kubiczak.test.spring.integration.demo.server.MockMvcSpringBaseTest
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 class EmployeesControllerMockMvcSpec extends MockMvcSpringBaseTest {
 

--- a/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/employees/EmployeesControllerMockMvcUnitSpec.groovy
+++ b/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/employees/EmployeesControllerMockMvcUnitSpec.groovy
@@ -1,14 +1,11 @@
 package pl.kubiczak.test.spring.integration.demo.server.employees
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import spock.lang.Specification
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 class EmployeesControllerMockMvcUnitSpec extends Specification {
 

--- a/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/employees/jdbc/EmployeeJdbcRepositoryEmbeddedSpec.groovy
+++ b/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/employees/jdbc/EmployeeJdbcRepositoryEmbeddedSpec.groovy
@@ -1,5 +1,8 @@
 package pl.kubiczak.test.spring.integration.demo.server.employees.jdbc
 
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseType
+
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.data.jdbc.test.autoconfigure.DataJdbcTest
@@ -10,9 +13,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.test.context.jdbc.Sql
 import pl.kubiczak.test.spring.integration.demo.server.TestDb
 import spock.lang.Specification
-
-import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider
-import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseType
 
 @DataJdbcTest(excludeAutoConfiguration = [
         AutoConfigureTestDatabase

--- a/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/employees/jpa/EmployeeJpaRepositoryEmbeddedSpec.groovy
+++ b/server/src/test/groovy/pl/kubiczak/test/spring/integration/demo/server/employees/jpa/EmployeeJpaRepositoryEmbeddedSpec.groovy
@@ -1,5 +1,8 @@
 package pl.kubiczak.test.spring.integration.demo.server.employees.jpa
 
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider
+import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseType
+
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase
 import org.hibernate.exception.ConstraintViolationException
 import org.springframework.beans.factory.annotation.Autowired
@@ -10,9 +13,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureDataSourceI
 import org.springframework.test.context.jdbc.Sql
 import pl.kubiczak.test.spring.integration.demo.server.TestDb
 import spock.lang.Specification
-
-import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider
-import static io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseType
 
 @DataJpaTest(excludeAutoConfiguration = [
         AutoConfigureTestDatabase


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized and consolidated import statements across multiple test specifications for improved code organization.
  * Replaced individual Spring MockMvc and WireMock static imports with wildcard imports in test files.
  * Updated embedded database test configuration with explicit PostgreSQL type and embedded provider settings.

* **Refactor**
  * Optimized test infrastructure imports for consistency across the test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiiitek/its/pull/512)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->